### PR TITLE
Removed json config values

### DIFF
--- a/JDBC/OAuthSampleApp/src/main/java/OAuthSampleApp.java
+++ b/JDBC/OAuthSampleApp/src/main/java/OAuthSampleApp.java
@@ -48,15 +48,11 @@ public class OAuthSampleApp implements Callable<Integer> {
     private String clientSecret = "";
 
     private static Connection connectToDB(String host, String port, String dbName, String accessToken,
-            String clientSecret, String refreshToken) throws SQLException {
+            String refreshToken, String clientSecret) throws SQLException {
         Properties jdbcOptions = new Properties();
         jdbcOptions.put("oauthaccesstoken", accessToken);
         jdbcOptions.put("oauthrefreshtoken", refreshToken);
-
-        // Put these options into static json config
-        String jsonConfig = "{ \"oauthclientsecret\" : \"" + clientSecret + "\" }";
-        System.out.println(jsonConfig);
-        jdbcOptions.put("oauthjsonconfig", jsonConfig);
+        jdbcOptions.put("oauthclientsecret", clientSecret);
 
         return DriverManager.getConnection(
                 "jdbc:vertica://" + host + ":" + port + "/" + dbName, jdbcOptions);
@@ -78,7 +74,7 @@ public class OAuthSampleApp implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         try {
-            Connection conn = connectToDB(host, port, dbName, accessToken, clientSecret, refreshToken);
+            Connection conn = connectToDB(host, port, dbName, accessToken, refreshToken, clientSecret);
             ResultSet rs = executeQuery(conn);
             printResults(rs);
             conn.close();

--- a/ODBC/OAuthSampleApp.cpp
+++ b/ODBC/OAuthSampleApp.cpp
@@ -76,12 +76,9 @@ void connectToDB(
     std::string refreshToken,
     std::string clientSecret)
 {
-    // Construct json config for static oauth config
-    std::string jsonConfig = std::string("{\"oauthclientsecret\" : \"" + clientSecret + "\"}");
-
     // Connect to the database
     std::cout << "Connecting to database." << std::endl;
-    ret = SQLDriverConnect(hdlDbc, NULL, (SQLCHAR *)("DSN=VerticaDSN;OAuthAccessToken=" + accessToken + ";OAuthRefreshToken=" + refreshToken + ";OAuthJsonConfig=" + jsonConfig).c_str(), SQL_NTS, NULL, 0, NULL, false);
+    ret = SQLDriverConnect(hdlDbc, NULL, (SQLCHAR *)("DSN=VerticaDSN;OAuthAccessToken=" + accessToken + ";OAuthRefreshToken=" + refreshToken + ";OAuthClientSecret=" + clientSecret).c_str(), SQL_NTS, NULL, 0, NULL, false);
     if (!SQL_SUCCEEDED(ret))
     {
         std::cout << "Could not connect to database" << std::endl;


### PR DESCRIPTION
The 24.1 release removes the oauthjsonconfig from the connection params.  It is no longer needed because the configuration values are sent by the server to the client.   The only exception is the client secret, which now has its own connection param.